### PR TITLE
Add Saved Posters button functionality

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -118,11 +118,8 @@ randomButton.addEventListener('click', function(){
 })
 
 savedButton.addEventListener('click', function(){
-
-})
-
-formButton.addEventListener('click', function(){
-
+  switchSections(mainSection);
+  switchSections(savedSection);
 })
 
 formButton.addEventListener('click', function() {


### PR DESCRIPTION
What (if any) features are you implementing?
- Made the "Show Saved Posters" button hide the main section and display the (thus-far empty) saved posters grid.
What (if anything) did you refactor?
- Deleted a duplicate form button event listener (which I realize now may have been there as a template for the next step; oops). 
Were there any issues that arose?
- Nope!
Is there anything that you need from your teammate?
- I know tossing the ball back and forth with these incredibly incremental updates is inefficient, but it's really helping me get comfortable with git workflow and pull requests, so thanks for your patience. 
Any other comments, questions, or concerns?
-
